### PR TITLE
更新：V1.0

### DIFF
--- a/src/main/java/org/mmga/mycraft/arrowfight/ArrowFightPlugin.java
+++ b/src/main/java/org/mmga/mycraft/arrowfight/ArrowFightPlugin.java
@@ -29,17 +29,17 @@ public final class ArrowFightPlugin extends JavaPlugin {
     @Override
     public void onEnable() {
         Logger log = super.getSLF4JLogger();
-        log.info(ChatColor.GREEN + "Start Loading...");
+        log.info("{}Start Loading...", ChatColor.GREEN);
         boolean b = this.checkEnvironment();
         if (b) {
-            log.error(ChatColor.RED + "缺少插件依赖！");
+            log.error("{}缺少插件依赖！", ChatColor.RED);
             disableMe();
             return;
         }
         this.hookPapi();
         PluginCommand af = super.getCommand("af");
         if (af == null) {
-            log.error(ChatColor.RED + "指令af注册失败！");
+            log.error("{}指令af注册失败！", ChatColor.RED);
             disableMe();
             return;
         }
@@ -51,6 +51,8 @@ public final class ArrowFightPlugin extends JavaPlugin {
         pluginManager.registerEvents(new BreakBlock(), this);
         pluginManager.registerEvents(new BlockExplode(), this);
         pluginManager.registerEvents(new PlayerReSpawn(), this);
+        pluginManager.registerEvents(new PlayerInteract(), this);
+        pluginManager.registerEvents(new PlayerDropItem(), this);
         ArrowFightCommand arrowFightCommand = new ArrowFightCommand();
         af.setExecutor(arrowFightCommand);
         af.setTabCompleter(arrowFightCommand);

--- a/src/main/java/org/mmga/mycraft/arrowfight/commands/ArrowFightCommand.java
+++ b/src/main/java/org/mmga/mycraft/arrowfight/commands/ArrowFightCommand.java
@@ -29,7 +29,13 @@ import java.util.Set;
  * @version 1.0.0
  */
 public class ArrowFightCommand implements CommandExecutor, TabCompleter {
+    private final static int SEC_TICK = 20;
+    private final static int FIVE_SEC = 5;
+    private final static int FIFTEEN_SEC = FIVE_SEC * 3;
+    private final static int HALF_MIN_SEC = FIFTEEN_SEC * 2;
+    private final static int MIN_SEC = HALF_MIN_SEC * 2;
     private static final String CREATE = "create";
+    private static final String FORCESTART = "forcestart";
     private static final String JOIN = "join";
     private static final String SETTINGS = "settings";
     private static final String REMOVE = "remove";
@@ -131,6 +137,19 @@ public class ArrowFightCommand implements CommandExecutor, TabCompleter {
                     sender.sendMessage(ChatColor.RED + "控制台无法加入游戏");
                 }
                 break;
+            case FORCESTART:
+                if (sender instanceof Player) {
+                    if (!sender.isOp()) {
+                        sender.sendMessage(ChatColor.RED + "你没有权限使用此指令");
+                        return;
+                    } else {
+                        GameObject ob = MapObject.PLAYERS.get(sender);
+                        if (ob != null) {
+                            ob.forceStart((Player) sender);
+                        }
+                    }
+                    break;
+                }
             default:
                 sendHelp(sender, args[0]);
                 break;
@@ -442,6 +461,7 @@ public class ArrowFightCommand implements CommandExecutor, TabCompleter {
             result.add(REMOVE);
             result.add(RELOAD);
             result.add(SAVE);
+            result.add(FORCESTART);
         }
         result.add(JOIN);
         result.add(HELP);

--- a/src/main/java/org/mmga/mycraft/arrowfight/events/BreakBlock.java
+++ b/src/main/java/org/mmga/mycraft/arrowfight/events/BreakBlock.java
@@ -13,6 +13,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.mmga.mycraft.arrowfight.entities.MapObject;
 
+import java.rmi.MarshalException;
 import java.util.Random;
 
 /**
@@ -34,7 +35,14 @@ public class BreakBlock implements Listener {
                     Location location = block.getLocation();
                     World world = location.getWorld();
                     Item entity = (Item) world.spawnEntity(location, EntityType.DROPPED_ITEM);
-                    entity.setItemStack(new ItemStack(Material.IRON_INGOT, new Random().nextInt(3) + 1));
+                    entity.setItemStack(new ItemStack(Material.IRON_INGOT, new Random().nextInt(4) + 1));
+                }
+                if (Material.COAL.equals(type)){
+                    event.setDropItems(false);
+                    Location location = block.getLocation();
+                    World world = location.getWorld();
+                    Item entity = (Item) world.spawnEntity(location, EntityType.DROPPED_ITEM);
+                    entity.setItemStack(new ItemStack(Material.COAL, new Random().nextInt(6) + 1));
                 }
                 if (Material.GOLD_ORE.equals(type)) {
                     event.setDropItems(false);

--- a/src/main/java/org/mmga/mycraft/arrowfight/events/EntityDamage.java
+++ b/src/main/java/org/mmga/mycraft/arrowfight/events/EntityDamage.java
@@ -8,11 +8,13 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByBlockEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
 import org.mmga.mycraft.arrowfight.ArrowFightPlugin;
+import org.mmga.mycraft.arrowfight.entities.GameObject;
 import org.mmga.mycraft.arrowfight.entities.MapObject;
 import org.mmga.mycraft.arrowfight.runnable.RemovePlayerPotionEffect;
 
@@ -46,8 +48,11 @@ public class EntityDamage implements Listener {
                 }
             }
         }
-        if (EntityType.PLAYER.equals(type) && EntityType.PLAYER.equals(damagerType)) {
-            event.setCancelled(true);
+        if (EntityType.PLAYER.equals(type) && damager instanceof Player) {
+            GameObject gameObject = MapObject.PLAYERS.get(damager);
+            if (!gameObject.isStart()) {
+                event.setCancelled(true);
+            }
         }
     }
 
@@ -56,6 +61,15 @@ public class EntityDamage implements Listener {
         Entity entity = event.getEntity();
         EntityType type = entity.getType();
         if (EntityType.VILLAGER.equals(type) && entity.getScoreboardTags().contains(GAME_TAG)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onEntityDamage(EntityDamageEvent event) {
+        Entity entity = event.getEntity();
+        EntityType type = entity.getType();
+        if (type.equals(EntityType.VILLAGER)){
             event.setCancelled(true);
         }
     }

--- a/src/main/java/org/mmga/mycraft/arrowfight/events/OnTick.java
+++ b/src/main/java/org/mmga/mycraft/arrowfight/events/OnTick.java
@@ -1,19 +1,20 @@
 package org.mmga.mycraft.arrowfight.events;
 
 import org.bukkit.*;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Block;
 import org.bukkit.entity.*;
-import org.bukkit.potion.PotionData;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionType;
+import org.bukkit.potion.*;
 import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.mmga.mycraft.arrowfight.ArrowFightPlugin;
 import org.mmga.mycraft.arrowfight.entities.GameObject;
 import org.mmga.mycraft.arrowfight.entities.MapObject;
 import org.mmga.mycraft.arrowfight.runnable.ArrowRain;
+import org.mmga.mycraft.arrowfight.entities.GameObject;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -43,8 +44,14 @@ public class OnTick extends BukkitRunnable {
             if (gameObjects != null) {
                 for (GameObject gameObject : gameObjects) {
                     gameObject.addTick();
+                    //显示游戏内tick
+                    //gameObject.sendToAll(ChatColor.RED + "tick:" + GameObject.tick, Sound.BLOCK_NOTE_BLOCK_BIT);
                     World copyWorld = gameObject.getCopyWorld();
                     Collection<Arrow> entitiesByClass = copyWorld.getEntitiesByClass(Arrow.class);
+                    //死斗模式时间检测
+                    if (GameObject.tick == 1800 + (20 * 600)) {
+                        gameObject.deathMatch();
+                    }
                     for (Arrow byClass : entitiesByClass) {
                         PotionData basePotionData = byClass.getBasePotionData();
                         PotionType type = basePotionData.getType();
@@ -157,8 +164,9 @@ public class OnTick extends BukkitRunnable {
                                 ArrowFightPlugin arrowFightPlugin = ArrowFightPlugin.getPlugin(ArrowFightPlugin.class);
                                 if (extended) {
                                     World worldCopied = gameObject.getCopyWorld();
-                                    LightningStrike spawn = worldCopied.spawn(arrowLocation, LightningStrike.class);
-                                    spawn.setLifeTicks(20);
+                                    worldCopied.strikeLightning(arrowLocation);
+//                                    LightningStrike spawn = worldCopied.spawn(arrowLocation, LightningStrike.class);
+//                                    spawn.setLifeTicks(20);
                                 } else {
                                     for (int i = 1; i < 3; i++) {
                                         new ArrowRain(arrowLocation).runTaskLater(arrowFightPlugin, i * 5);
@@ -202,9 +210,10 @@ public class OnTick extends BukkitRunnable {
                     for (Villager entity : entities) {
                         if (entity.getScoreboardTags().contains(EntityDamage.GAME_TAG)) {
                             for (PotionEffect activePotionEffect : entity.getActivePotionEffects()) {
-                                entity.removePotionEffect(activePotionEffect.getType());
+                                PotionEffectType effectType = activePotionEffect.getType();
+                                    entity.removePotionEffect(effectType);
                             }
-                            entity.setAI(false);
+//                            entity.setAI(false);
                         }
                     }
                     if (runSec) {

--- a/src/main/java/org/mmga/mycraft/arrowfight/events/PlayerDropItem.java
+++ b/src/main/java/org/mmga/mycraft/arrowfight/events/PlayerDropItem.java
@@ -1,0 +1,32 @@
+package org.mmga.mycraft.arrowfight.events;
+
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerDropItemEvent;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+public class PlayerDropItem implements Listener {
+
+    private static final Collection<Material> cannotDropItems;
+
+    static {
+        cannotDropItems = new HashSet<>();
+        cannotDropItems.add(Material.BOW);
+        cannotDropItems.add(Material.SLIME_BALL);
+    }
+
+    @EventHandler
+    public void onPlayerDropItem(PlayerDropItemEvent event) {
+        Material itemType = event.getItemDrop().getItemStack().getType();
+        String worldName = event.getPlayer().getWorld().getName();
+        if (worldName.equalsIgnoreCase("lobby")){
+            return;
+        }
+        if (cannotDropItems.contains(itemType)) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/org/mmga/mycraft/arrowfight/events/PlayerInteract.java
+++ b/src/main/java/org/mmga/mycraft/arrowfight/events/PlayerInteract.java
@@ -1,0 +1,34 @@
+package org.mmga.mycraft.arrowfight.events;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+
+import javax.naming.NamingEnumeration;
+
+public class PlayerInteract implements Listener {
+
+    @EventHandler
+    public void onPlayerTryToLeaveGame(PlayerInteractEvent event){
+        Player player = event.getPlayer();
+        ItemStack mainHandItem = player.getInventory().getItemInMainHand();
+        String worldName = player.getWorld().getName();
+        if (!(event.getAction().equals(Action.RIGHT_CLICK_AIR) || event.getAction().equals(Action.RIGHT_CLICK_BLOCK))) {
+            return;
+        }
+        if (worldName.equalsIgnoreCase("lobby")){
+            return;
+        }
+        if (mainHandItem.getType().equals(Material.SLIME_BALL)){
+            player.performCommand("af leave");
+        }
+    }
+}

--- a/src/main/java/org/mmga/mycraft/arrowfight/events/PlayerJoin.java
+++ b/src/main/java/org/mmga/mycraft/arrowfight/events/PlayerJoin.java
@@ -1,10 +1,13 @@
 package org.mmga.mycraft.arrowfight.events;
 
 import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.inventory.PlayerInventory;
 import org.mmga.mycraft.arrowfight.entities.GameObject;
 import org.mmga.mycraft.arrowfight.entities.MapObject;
 
@@ -41,6 +44,14 @@ public class PlayerJoin implements Listener {
                 TEAMS.remove(name);
                 MapObject.PLAYERS.put(player, gameObject);
                 MapObject.PLAYERS.remove(oldP);
+            }
+        } else {
+            World world = player.getWorld();
+            World lobby = Bukkit.getWorld("Lobby");
+            PlayerInventory playerInventory = player.getInventory();
+            assert lobby != null;
+            if (lobby.equals(world)) {
+                playerInventory.clear();
             }
         }
     }

--- a/src/main/java/org/mmga/mycraft/arrowfight/utils/VillagerUtils.java
+++ b/src/main/java/org/mmga/mycraft/arrowfight/utils/VillagerUtils.java
@@ -2,9 +2,12 @@ package org.mmga.mycraft.arrowfight.utils;
 
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.entity.Villager;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.MerchantRecipe;
+import org.bukkit.inventory.meta.CompassMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffect;
@@ -14,27 +17,29 @@ import org.mmga.mycraft.arrowfight.events.EntityDamage;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
 
-import static org.bukkit.ChatColor.GREEN;
-import static org.bukkit.ChatColor.RED;
+import static org.bukkit.ChatColor.*;
 import static org.bukkit.Material.*;
 import static org.bukkit.potion.PotionType.*;
 
-/**
- * Created On 2022/8/9 13:50
- *
- * @author wzp
- * @version 1.0.0
- */
 public class VillagerUtils {
 
     private static final ItemStack ARROW_ITEM = new ItemStack(ARROW, 2);
     private static final MerchantRecipe IRON_ARROW = new MerchantRecipe(ARROW_ITEM, 99999);
     private static final List<MerchantRecipe> MERCHANT_RECIPES = new ArrayList<>();
 
+    /*
+        村民交易内容
+        可选方法:addItem(),addNormalItem()
+        参数解析(两个方法常用参数相同):出售物品（箭矢效果），数量，出售物品名称，所需物品，数量，出售物品描述
+    */
     static {
         IRON_ARROW.addIngredient(new ItemStack(COBBLESTONE, 1));
         MERCHANT_RECIPES.add(IRON_ARROW);
+        addNormalItem(OAK_PLANKS, 4, GREEN + "木板", IRON_INGOT, 2, RED + "没想到吧，木板这么贵。但是你就说你买不买吧");
+        addNormalItem(GOLDEN_APPLE, 1 ,AQUA + "金苹果", GOLD_INGOT, 3, RED + "好吧，看来你在这里也能买到金苹果");
         addItem(INVISIBILITY, 3, RED + "TNT箭矢", REDSTONE, 12, RED + "会在射到的地方生成一个TNT");
         addItem(INVISIBILITY, true, false, 1, RED + "TNT雨箭矢", REDSTONE, 20, RED + "会在射到的地方生成一场TNT雨");
         addItem(POISON, 1, GREEN + "苦力怕箭矢", EMERALD, 3, GREEN + "会在射到的地方生成亿些苦力怕");
@@ -59,6 +64,24 @@ public class VillagerUtils {
         villager.setRecipes(MERCHANT_RECIPES);
     }
 
+    //添加常规物品
+    private static void addNormalItem(Material item, int count, String name, Material need, int needCount, String... lores) {
+        List<Component> lore = new ArrayList<>();
+        for (String l : lores) {
+            lore.add(Component.text(l));
+        }
+        ItemStack normalItem = new ItemStack(item, count);
+        ItemMeta normalItemMeta = normalItem.getItemMeta();
+        normalItemMeta.displayName(Component.text(name));
+        normalItemMeta.lore(lore);
+        normalItem.setItemMeta(normalItemMeta);
+        MerchantRecipe merchantRecipe = new MerchantRecipe(normalItem, 9999999);
+        merchantRecipe.addIngredient(new ItemStack(need, needCount));
+        MERCHANT_RECIPES.add(merchantRecipe);
+
+    }
+
+    //添加箭矢初始化
     private static void addItem(PotionType type, boolean extended, boolean upgraded, int count, String name, Material need, int needCount, String... lores) {
         List<Component> lore = new ArrayList<>();
         for (String l : lores) {
@@ -75,6 +98,7 @@ public class VillagerUtils {
         MERCHANT_RECIPES.add(merchantRecipe);
     }
 
+    //添加箭矢
     private static void addItem(PotionType type, int count, String name, Material need, int needCount, String... lores) {
         addItem(type, false, false, count, name, need, needCount, lores);
     }


### PR DESCRIPTION
     闪电箭现在可以正常召唤出闪电了
修改：游戏开始前，玩家的游戏模式将会被修改为冒险模式,而不是旁观模式
     修改了金锭、铁锭和煤炭的掉落数量
     死斗模式改为给予物资（绿宝石64，圆石256，红石块32，金苹果32，盾牌1，泥土64）
新增：玩家现在在大厅（lobby）以外的世界可以使用粘液球退出游戏
     玩家现在不能丢弃粘液球和弓
     新增了一些交易物品
     新增了命令forceStart，可用于强制开始游戏